### PR TITLE
Single constant propogation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,16 @@
+sudo: required
+
+services:
+ - docker
+
 language: java
+
+before_install:
+ - docker build -t wimkeir/green .
+ - docker run -d -p 127.0.0.1:80:4567 wimkeir/green /bin/sh -c "cd /root/green;
+   ant;"
+ - docker ps -a
+ - docker run wimkeir/green /bin/sh -c "/root/green; ant test;"
 
 script:
  - ant;

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ language: java
 before_install:
  - docker build -t wimkeir/green .
  - docker run -d -p 127.0.0.1:80:4567 wimkeir/green /bin/sh -c "cd /root/green;
-   ant;"
- - docker ps -a
- - docker run wimkeir/green /bin/sh -c "cd /root/green; ant test;"
+   ant; ant test;"
 
 script:
  - ant;

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ language: java
 services:
  - docker
 
-before_install:
+script:
  - docker build -t wimkeir/green .
  - docker run wimkeir/green /bin/sh -c "ant; ant test;"
-
-script:
- - ant;
- - ant test;

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,3 @@ services:
 script:
  - docker build -t wimkeir/green .
  - docker run wimkeir/green /bin/sh -c "ant; ant test;"
- - CONTAINERID="$(docker inspect --format="{{.Id}}" wimkeir/green)"
- - docker logs -t $CONTAINERID

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ services:
 script:
  - docker build -t wimkeir/green .
  - docker run wimkeir/green /bin/sh -c "ant; ant test;"
- - docker logs
+ - docker inspect --format="{{.Id}}" wimkeir/green
+ - docker logs -t $?

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 sudo: required
 
+language: java
+
 services:
  - docker
 
-language: java
-
 before_install:
  - docker build -t wimkeir/green .
- - docker run -d -p 127.0.0.1:80:4567 wimkeir/green /bin/sh -c "cd /root/green;
-   ant; ant test;"
+ - docker run wimkeir/green /bin/sh -c "ant; ant test;"
 
 script:
  - ant;

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ services:
 script:
  - docker build -t wimkeir/green .
  - docker run wimkeir/green /bin/sh -c "ant; ant test;"
+ - docker logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
  - docker run -d -p 127.0.0.1:80:4567 wimkeir/green /bin/sh -c "cd /root/green;
    ant;"
  - docker ps -a
- - docker run wimkeir/green /bin/sh -c "/root/green; ant test;"
+ - docker run wimkeir/green /bin/sh -c "cd /root/green; ant test;"
 
 script:
  - ant;

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ services:
 script:
  - docker build -t wimkeir/green .
  - docker run wimkeir/green /bin/sh -c "ant; ant test;"
- - docker inspect --format="{{.Id}}" wimkeir/green
- - docker logs -t $?
+ - CONTAINERID="$(docker inspect --format="{{.Id}}" wimkeir/green)"
+ - docker logs -t $CONTAINERID

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN git clone https://github.com/wimkeir/green
 # Checkout the constant propagation branch
 WORKDIR /green
 RUN git fetch
-RUN git checkout feature/constant-propagation>
+RUN git checkout feature/constant-propagation
 WORKDIR /
 
 # Download and extract Z3

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,12 @@ RUN apt install libgomp1
 # Clone down the GreenSolver repository
 RUN git clone https://github.com/wimkeir/green
 
+# Checkout the constant propagation branch
+WORKDIR /green
+RUN git fetch
+RUN git checkout feature/constant-propagation>
+WORKDIR /
+
 # Download and extract Z3
 RUN mkdir z3
 WORKDIR z3

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt install patchelf -y
 RUN apt install libgomp1
 
 # Clone down the GreenSolver repository
-RUN git clone https://github.com/wvisser/green
+RUN git clone https://github.com/wimkeir/green
 
 # Download and extract Z3
 RUN mkdir z3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/wvisser/green.svg?branch=master)](https://travis-ci.org/wvisser/green.svg?branch=master)
+[![Build
+Status](https://travis-ci.org/wimkeir/green.svg?branch=master)](https://travis-ci.org/wimkeir/green.svg?branch=master)
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-[![Build
-Status](https://travis-ci.org/wimkeir/green.svg?branch=master)](https://travis-ci.org/wimkeir/green.svg?branch=master)
+[![Build Status](https://travis-ci.org/wimkeir/green.svg?branch=master)](https://travis-ci.org/wimkeir/green)
 
 Notes:
 
 The first step is to update "build.properties" with your local
 settings.  You do not need to set z3 and latte, but in that case
 some unit tests won't run.
-   

--- a/build.xml
+++ b/build.xml
@@ -96,8 +96,8 @@
     	<echo message="java.library.path = ${z3lib};${cvc3lib}"/>
         <mkdir dir="${junit.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr" haltonfailure = "yes">
-            <formatter type="xml"/>
-			<formatter type="plain" usefile="false"/>
+            <formatter type="plain"/>
+            <formatter type="plain" usefile="false"/>
             <test name="za.ac.sun.cs.green.EntireSuite" todir="${junit.dir}"/>
             <env key="DYLD_LIBRARY_PATH" value="lib"/>
             <env key="LD_LIBRARY_PATH" value="lib"/>

--- a/build.xml
+++ b/build.xml
@@ -95,7 +95,7 @@
     <target name="test">
     	<echo message="java.library.path = ${z3lib};${cvc3lib}"/>
         <mkdir dir="${junit.dir}"/>
-        <junit fork="yes" printsummary="withOutAndErr" haltonfailure = "yes">
+        <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="plain"/>
             <formatter type="plain" usefile="false"/>
             <test name="za.ac.sun.cs.green.EntireSuite" todir="${junit.dir}"/>

--- a/build.xml
+++ b/build.xml
@@ -42,7 +42,7 @@
     	<pathelement location="test"/>
     </path>
     <property name="green.srcpath" refid="green.srcpath"/>
-    
+
 <!--
     Initialization
 -->
@@ -97,6 +97,7 @@
         <mkdir dir="${junit.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr" haltonfailure = "yes">
             <formatter type="xml"/>
+			<formatter type="plain" usefile="false"/>
             <test name="za.ac.sun.cs.green.EntireSuite" todir="${junit.dir}"/>
             <env key="DYLD_LIBRARY_PATH" value="lib"/>
             <env key="LD_LIBRARY_PATH" value="lib"/>

--- a/deliverable_1.txt
+++ b/deliverable_1.txt
@@ -1,0 +1,11 @@
+The problem was a missing "=" character in the test oracle.
+
+This was found by adding a formatter to the JUnit target in build.xml to print
+detailed output (including failing tests with their expected values) to the
+terminal (thank you StackOverflow).
+
+While searching I did discover that JUnit was already actually printing the
+desired output to a file somewhere in /bin, but I left my changes as is because
+printing errors to the terminal is nice as well.
+
+The repo is at https://github.com/wimkeir/green

--- a/src/za/ac/sun/cs/green/service/simplify/ConstantPropogation.java
+++ b/src/za/ac/sun/cs/green/service/simplify/ConstantPropogation.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Set;
 import java.util.Stack;
+import java.util.logging.Level;
 
 import za.ac.sun.cs.green.Green;
 import za.ac.sun.cs.green.Instance;
@@ -38,12 +39,14 @@ public class ConstantPropogation extends BasicService {
 
 	public Expression simplify(Expression expression) {
 		try {
+			log.log(Level.FINEST, "Before simplification: " + expression);
 			SimplificationVisitor simplificationVisitor = new SimplificationVisitor();
 			expression.accept(simplificationVisitor);
 			Expression simplified = simplificationVisitor.getExpression();
+			log.log(Level.FINEST, "After simplification: " + simplified);
 			return simplified;
 		} catch (VisitorException x) {
-			System.out.println("Houston, we have a problem!" + x);
+			log.log(Level.SEVERE, "Houston, we have a problem!", x);
 		}
 		return null;
 	}

--- a/src/za/ac/sun/cs/green/service/simplify/ConstantPropogation.java
+++ b/src/za/ac/sun/cs/green/service/simplify/ConstantPropogation.java
@@ -1,7 +1,18 @@
 package za.ac.sun.cs.green.service.simplify;
 
+import java.util.Collections;
+import java.util.Set;
+import java.util.Stack;
+
 import za.ac.sun.cs.green.Green;
+import za.ac.sun.cs.green.Instance;
 import za.ac.sun.cs.green.service.BasicService;
+import za.ac.sun.cs.green.expr.Constant;
+import za.ac.sun.cs.green.expr.Operation;
+import za.ac.sun.cs.green.expr.Variable;
+import za.ac.sun.cs.green.expr.Expression;
+import za.ac.sun.cs.green.expr.Visitor;
+import za.ac.sun.cs.green.expr.VisitorException;
 
 public class ConstantPropogation extends BasicService {
 
@@ -9,4 +20,62 @@ public class ConstantPropogation extends BasicService {
 		super(solver);
 	}
 
+	@Override
+	public Set<Instance> processRequest(Instance instance) {
+		@SuppressWarnings("unchecked")
+		Set<Instance> result = (Set<Instance>) instance.getData(getClass());
+		if (result == null) {
+			final Expression e = simplify(instance.getFullExpression());
+			final Instance i = new Instance(getSolver(), instance.getSource(), null, e);
+			result = Collections.singleton(i);
+			instance.setData(getClass(), result);
+		}
+		return result;
+	}
+
+	public Expression simplify(Expression expression) {
+		try {
+			System.out.println("Before simplification: " + expression);		// XXX
+			SimplificationVisitor simplificationVisitor = new SimplificationVisitor();
+			expression.accept(simplificationVisitor);
+			Expression simplified = simplificationVisitor.getExpression();
+			System.out.println("After simplification: " + expression);		// XXX
+			return simplified;
+		} catch (VisitorException x) {
+			System.out.println("Houston, we have a problem!" + x);
+		}
+		return null;
+	}
+
+	private static class SimplificationVisitor extends Visitor {
+
+		private Stack<Expression> stack;
+
+		public SimplificationVisitor() {
+			stack = new Stack<Expression>();
+		}
+
+		public Expression getExpression() {
+			return stack.pop();
+		}
+
+		@Override
+		public void postVisit(Variable variable) {
+			System.out.println("Pushing variable " + variable);
+			stack.push(variable);
+		}
+
+		@Override
+		public void postVisit(Constant constant) {
+			System.out.println("Pushing constant " + constant);
+			stack.push(constant);
+		}
+
+		@Override
+		public void postVisit(Operation operation) {
+			System.out.println("Pushing operation " + operation);
+			System.out.println(operation.getOperator().equals(Operation.Operator.EQ));
+			stack.push(operation);
+		}
+	}
 }

--- a/src/za/ac/sun/cs/green/service/simplify/ConstantPropogation.java
+++ b/src/za/ac/sun/cs/green/service/simplify/ConstantPropogation.java
@@ -1,0 +1,12 @@
+package za.ac.sun.cs.green.service.simplify;
+
+import za.ac.sun.cs.green.Green;
+import za.ac.sun.cs.green.service.BasicService;
+
+public class ConstantPropogation extends BasicService {
+
+	public ConstantPropogation(Green solver) {
+		super(solver);
+	}
+
+}

--- a/test/za/ac/sun/cs/green/EntireSuite.java
+++ b/test/za/ac/sun/cs/green/EntireSuite.java
@@ -25,6 +25,7 @@ import za.ac.sun.cs.green.service.cvc3.SATCVC3Test;
 import za.ac.sun.cs.green.service.factorizer.SATFactorizerTest;
 import za.ac.sun.cs.green.service.latte.CountLattETest;
 import za.ac.sun.cs.green.service.latte.CountLattEWithBounderTest;
+import za.ac.sun.cs.green.service.simplify.OnlyConstantPropogationTest;
 import za.ac.sun.cs.green.service.slicer.ParallelSATSlicerTest;
 import za.ac.sun.cs.green.service.slicer.SATSlicerTest;
 import za.ac.sun.cs.green.service.z3.SATZ3JavaTest;
@@ -36,7 +37,8 @@ import za.ac.sun.cs.green.util.SetTaskManagerTest;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
 	SATCanonizerTest.class,
-	SATZ3Test.class
+	SATZ3Test.class,
+	OnlyConstantPropogationTest.class
 })
 
 public class EntireSuite {
@@ -75,9 +77,9 @@ public class EntireSuite {
 		Z3_PATH = z3;
 		HAS_Z3 = checkZ3Presence();
 		if (!HAS_Z3) {
-		  System.out.println("Z3 Not Available, no tests for it will be executed");	
+		  System.out.println("Z3 Not Available, no tests for it will be executed");
 		}
-		
+
 	}
 
 	private static boolean checkCVC3Presence() {

--- a/test/za/ac/sun/cs/green/EntireSuite.java
+++ b/test/za/ac/sun/cs/green/EntireSuite.java
@@ -40,7 +40,7 @@ import za.ac.sun.cs.green.util.SetTaskManagerTest;
 	SATCanonizerTest.class,
 	SATZ3Test.class,
 	OnlyConstantPropogationTest.class,
-	// SimplificationConstantPropogationTest.class
+	SimplificationConstantPropogationTest.class
 })
 
 public class EntireSuite {

--- a/test/za/ac/sun/cs/green/EntireSuite.java
+++ b/test/za/ac/sun/cs/green/EntireSuite.java
@@ -26,6 +26,7 @@ import za.ac.sun.cs.green.service.factorizer.SATFactorizerTest;
 import za.ac.sun.cs.green.service.latte.CountLattETest;
 import za.ac.sun.cs.green.service.latte.CountLattEWithBounderTest;
 import za.ac.sun.cs.green.service.simplify.OnlyConstantPropogationTest;
+import za.ac.sun.cs.green.service.simplify.SimplificationConstantPropogationTest;
 import za.ac.sun.cs.green.service.slicer.ParallelSATSlicerTest;
 import za.ac.sun.cs.green.service.slicer.SATSlicerTest;
 import za.ac.sun.cs.green.service.z3.SATZ3JavaTest;
@@ -38,7 +39,8 @@ import za.ac.sun.cs.green.util.SetTaskManagerTest;
 @Suite.SuiteClasses({
 	SATCanonizerTest.class,
 	SATZ3Test.class,
-	OnlyConstantPropogationTest.class
+	OnlyConstantPropogationTest.class,
+	// SimplificationConstantPropogationTest.class
 })
 
 public class EntireSuite {

--- a/test/za/ac/sun/cs/green/service/canonizer/SATCanonizerTest.java
+++ b/test/za/ac/sun/cs/green/service/canonizer/SATCanonizerTest.java
@@ -98,7 +98,7 @@ public class SATCanonizerTest {
 		IntVariable v2 = new IntVariable("bb", 0, 99);
 		IntConstant c2 = new IntConstant(1);
 		Operation o2 = new Operation(Operation.Operator.NE, v2, c2);
-		check(o1, o2, "(aa==0)&&(bb!=1)", "1*v==0");
+		check(o1, o2, "(aa==0)&&(bb=1)", "1*v==0");
 	}
 
 	@Test

--- a/test/za/ac/sun/cs/green/service/canonizer/SATCanonizerTest.java
+++ b/test/za/ac/sun/cs/green/service/canonizer/SATCanonizerTest.java
@@ -98,7 +98,7 @@ public class SATCanonizerTest {
 		IntVariable v2 = new IntVariable("bb", 0, 99);
 		IntConstant c2 = new IntConstant(1);
 		Operation o2 = new Operation(Operation.Operator.NE, v2, c2);
-		check(o1, o2, "(aa==0)&&(bb=1)", "1*v==0");
+		check(o1, o2, "(aa==0)&&(bb!=1)", "1*v==0");
 	}
 
 	@Test

--- a/test/za/ac/sun/cs/green/service/canonizer/SATCanonizerTest.java
+++ b/test/za/ac/sun/cs/green/service/canonizer/SATCanonizerTest.java
@@ -293,7 +293,7 @@ public class SATCanonizerTest {
 		Operation o1 = new Operation(Operation.Operator.LE, c1, c1);
 		check(o1, "2<=2", "0==0");
 	}
-/*
+
 	@Test
 	public void test20() {
 		IntConstant c1 = new IntConstant(2);
@@ -301,7 +301,7 @@ public class SATCanonizerTest {
 		Operation o1 = new Operation(Operation.Operator.LE, c1, c1);
 		Operation o2 = new Operation(Operation.Operator.LT, v1, c1);
 		Operation o3 = new Operation(Operation.Operator.AND, o1, o2);
-		check(o3, "(2<=2)&&(aa<2)", "1*v+-1<0");
+		check(o3, "(2<=2)&&(aa<2)", "1*v+-1<=0");
 	}
-*/
+
 }

--- a/test/za/ac/sun/cs/green/service/simplify/OnlyConstantPropogationTest.java
+++ b/test/za/ac/sun/cs/green/service/simplify/OnlyConstantPropogationTest.java
@@ -1,0 +1,74 @@
+package za.ac.sun.cs.green.service.simplify;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import za.ac.sun.cs.green.Instance;
+import za.ac.sun.cs.green.Green;
+import za.ac.sun.cs.green.expr.Expression;
+import za.ac.sun.cs.green.expr.IntConstant;
+import za.ac.sun.cs.green.expr.IntVariable;
+import za.ac.sun.cs.green.expr.Operation;
+import za.ac.sun.cs.green.util.Configuration;
+
+public class OnlyConstantPropogationTest {
+
+	public static Green solver;
+
+	@BeforeClass
+		public static void initialize() {
+			solver = new Green();
+			Properties props = new Properties();
+			props.setProperty("green.services", "sat");
+			props.setProperty("green.service.sat", "(simplify sink)");
+			//props.setProperty("green.service.sat", "(canonize sink)");
+			props.setProperty("green.service.sat.simplify",
+					"za.ac.sun.cs.green.service.simplify.ConstantPropogation");
+			//props.setProperty("green.service.sat.canonize",
+			//		"za.ac.sun.cs.green.service.canonizer.SATCanonizerService");
+
+			props.setProperty("green.service.sat.sink",
+					"za.ac.sun.cs.green.service.sink.SinkService");
+			Configuration config = new Configuration(solver, props);
+			config.configure();
+		}
+
+	private void finalCheck(String observed, String expected) {
+		assertEquals(expected, observed);
+	}
+
+	private void check(Expression expression, String expected) {
+		Instance i = new Instance(solver, null, null, expression);
+		Expression e = i.getExpression();
+		assertTrue(e.equals(expression));
+		assertEquals(expression.toString(), e.toString());
+		Object result = i.request("sat");
+		assertNotNull(result);
+		assertEquals(Instance.class, result.getClass());
+		Instance j = (Instance) result;
+		finalCheck(j.getExpression().toString(), expected);
+	}
+
+	@Test
+	public void test00() {
+		IntVariable x = new IntVariable("x", 0, 99);
+		IntVariable y = new IntVariable("y", 0, 99);
+		IntVariable z = new IntVariable("z", 0, 99);
+		IntConstant c = new IntConstant(1);
+		IntConstant c10 = new IntConstant(10);
+		IntConstant c3 = new IntConstant(3);
+		Operation o1 = new Operation(Operation.Operator.EQ, x, c); // o1 : x = 1
+		Operation o2 = new Operation(Operation.Operator.ADD, x, y); // o2 : (x + y)
+		Operation o3 = new Operation(Operation.Operator.EQ, o2, c10); // o3 : x+y = 10
+		Operation o4 = new Operation(Operation.Operator.AND, o1, o3); // o4 : x = 1 && (x+y) = 10
+		check(o4, "(x==1)&&((1+y)==10)");
+	}
+
+}

--- a/test/za/ac/sun/cs/green/service/simplify/SimplificationConstantPropogationTest.java
+++ b/test/za/ac/sun/cs/green/service/simplify/SimplificationConstantPropogationTest.java
@@ -1,0 +1,186 @@
+package za.ac.sun.cs.green.service.simplify;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import za.ac.sun.cs.green.Instance;
+import za.ac.sun.cs.green.Green;
+import za.ac.sun.cs.green.expr.Expression;
+import za.ac.sun.cs.green.expr.IntConstant;
+import za.ac.sun.cs.green.expr.IntVariable;
+import za.ac.sun.cs.green.expr.Operation;
+import za.ac.sun.cs.green.util.Configuration;
+
+public class SimplificationConstantPropogationTest {
+
+	public static Green solver;
+
+	@BeforeClass
+		public static void initialize() {
+			solver = new Green();
+			Properties props = new Properties();
+			props.setProperty("green.services", "sat");
+			props.setProperty("green.service.sat", "(simplify sink)");
+			//props.setProperty("green.service.sat", "(canonize sink)");
+			props.setProperty("green.service.sat.simplify",
+					"za.ac.sun.cs.green.service.simplify.ConstantPropogation");
+			//props.setProperty("green.service.sat.canonize",
+			//		"za.ac.sun.cs.green.service.canonizer.SATCanonizerService");
+
+			props.setProperty("green.service.sat.sink",
+					"za.ac.sun.cs.green.service.sink.SinkService");
+			Configuration config = new Configuration(solver, props);
+			config.configure();
+		}
+
+	private void finalCheck(String observed, String expected) {
+		assertEquals(expected, observed);
+	}
+
+	private void check(Expression expression, String expected) {
+		Instance i = new Instance(solver, null, null, expression);
+		Expression e = i.getExpression();
+		assertTrue(e.equals(expression));
+		assertEquals(expression.toString(), e.toString());
+		Object result = i.request("sat");
+		assertNotNull(result);
+		assertEquals(Instance.class, result.getClass());
+		Instance j = (Instance) result;
+		finalCheck(j.getExpression().toString(), expected);
+	}
+
+	@Test
+	public void test00() {
+		IntVariable x = new IntVariable("x", 0, 99);
+		IntVariable y = new IntVariable("y", 0, 99);
+		IntVariable z = new IntVariable("z", 0, 99);
+		IntConstant c = new IntConstant(1);
+		IntConstant c10 = new IntConstant(10);
+		IntConstant c3 = new IntConstant(3);
+		Operation o1 = new Operation(Operation.Operator.EQ, x, c); // o1 : x = 1
+		Operation o2 = new Operation(Operation.Operator.ADD, x, y); // o2 : (x + y)
+		Operation o3 = new Operation(Operation.Operator.EQ, o2, c10); // o3 : x+y = 10
+		Operation o4 = new Operation(Operation.Operator.AND, o1, o3); // o4 : x = 1 && (x+y) = 10
+		check(o4, "(x==1)&&(y==9)");
+	}
+
+	@Test
+	public void test01() {
+		IntVariable x = new IntVariable("x", 0, 99);
+		IntVariable y = new IntVariable("y", 0, 99);
+		IntConstant c = new IntConstant(1);
+		IntConstant c2 = new IntConstant(10);
+		IntConstant c3 = new IntConstant(2);
+		Operation o1 = new Operation(Operation.Operator.EQ, x, c); // o1 : (x = 1)
+		Operation o2 = new Operation(Operation.Operator.ADD, x, y); // o2 : x + y
+		Operation o3 = new Operation(Operation.Operator.LT, o2, c2); // o3 : (x+y) < 10
+		Operation oi = new Operation(Operation.Operator.SUB, y, c); // oi : y-1
+		Operation o4 = new Operation(Operation.Operator.EQ, oi, c3); // o4 : y-1 = 2
+		Operation o5 = new Operation(Operation.Operator.AND, o1, o3); // o5 : (x = 1) && (x+y < 10)
+		Operation o = new Operation(Operation.Operator.AND, o5, o4); // o = (x = 1) && (x+y < 10) && (y-1 = 2)
+		// (x = 1) && (x+y < 10) && (y-1 = 2)
+		check(o, "(x==1)&&(y==3)");
+	}
+
+	@Test
+		public void test02() {
+			IntConstant c1 = new IntConstant(4);
+			IntConstant c2 = new IntConstant(10);
+			Operation o = new Operation(Operation.Operator.LT, c1, c2);
+			check(o, "0==0");
+		}
+
+	@Test
+		public void test03() {
+			IntConstant c1 = new IntConstant(4);
+			IntConstant c2 = new IntConstant(10);
+			Operation o = new Operation(Operation.Operator.GT, c1, c2);
+			check(o, "0==1");
+		}
+
+	@Test
+		public void test04() {
+			IntConstant c1 = new IntConstant(4);
+			IntConstant c2 = new IntConstant(10);
+			Operation o1 = new Operation(Operation.Operator.LT, c1, c2);
+			Operation o2 = new Operation(Operation.Operator.GT, c1, c2);
+			Operation o = new Operation(Operation.Operator.AND, o1, o2);
+			check(o, "0==1");
+		}
+
+
+
+
+	@Test
+		public void test05() {
+			IntVariable x = new IntVariable("x", 0, 99);
+			IntVariable y = new IntVariable("y", 0, 99);
+			IntConstant c = new IntConstant(1);
+			IntConstant c2 = new IntConstant(10);
+			IntConstant c3 = new IntConstant(2);
+			Operation o1 = new Operation(Operation.Operator.EQ, c, x);
+			Operation o2 = new Operation(Operation.Operator.ADD, x, y);
+			Operation o3 = new Operation(Operation.Operator.LT, o2, c2);
+			Operation oi = new Operation(Operation.Operator.SUB, y, c);
+			Operation o4 = new Operation(Operation.Operator.EQ, c3, oi);
+			Operation o5 = new Operation(Operation.Operator.AND, o1, o3);
+			Operation o = new Operation(Operation.Operator.AND, o5, o4);
+			check(o, "(1==x)&&(3==y)");
+		}
+
+	@Test
+		public void test06() {
+			IntVariable x = new IntVariable("x", 0, 99);
+			IntVariable y = new IntVariable("y", 0, 99);
+			IntVariable z = new IntVariable("z", 0 , 99);
+			IntConstant c = new IntConstant(1);
+			Operation o1 = new Operation(Operation.Operator.EQ, x, y);
+			Operation o2 = new Operation(Operation.Operator.EQ, y, z);
+			Operation o3 = new Operation(Operation.Operator.EQ, z, c);
+			Operation o = new Operation(Operation.Operator.AND, o1, o2);
+			o = new Operation(Operation.Operator.AND, o, o3);
+			check(o, "(x==1)&&((y==1)&&(z==1))");
+		}
+
+	@Test
+		public void test07() {
+			IntVariable x = new IntVariable("x", 0, 99);
+			IntVariable y = new IntVariable("y", 0, 99);
+			IntVariable z = new IntVariable("z", 0 , 99);
+			IntConstant c = new IntConstant(2);
+			IntConstant c1 = new IntConstant(4);
+			Operation o1 = new Operation(Operation.Operator.MUL, x, y);
+			Operation o2 = new Operation(Operation.Operator.EQ, z, o1); // z = x * y
+			Operation o3 = new Operation(Operation.Operator.EQ, x, c); // x = 2
+			Operation o4 = new Operation(Operation.Operator.ADD, y, x);
+			Operation o5 = new Operation(Operation.Operator.EQ, o4, c1); // x+y = 4
+
+			Operation o = new Operation(Operation.Operator.AND, o2, o3); // z = x * y && x = 2
+			o = new Operation(Operation.Operator.AND, o, o5); // z = x * y && x = 2 && x+y = 4
+			check(o, "(z==4)&&((x==2)&&(y==2))");
+		}
+
+	@Test
+		public void test08() {
+			IntVariable x = new IntVariable("x", 0, 99);
+			IntConstant c = new IntConstant(2);
+			IntConstant c1 = new IntConstant(4);
+			Operation o1 = new Operation(Operation.Operator.EQ, x, c);
+			Operation o2 = new Operation(Operation.Operator.EQ, x, c1);
+			Operation o = new Operation(Operation.Operator.AND, o1, o2);
+
+			check(o, "0==1");
+		}
+
+
+
+
+
+}


### PR DESCRIPTION
@PhillipVH @Monkleys @Zhunaidm @steynvl

Apologies for leaving this so late. Could one of you please give this a review when you have the chance? I've managed to get single propogation working (so `OnlyConstantPropogationTest` is passing). Only the last seven commits are relevant (from 9 August), the previous commits are from tut 1.

On the first pass, `SimplificationVisitor` notes all variable assignments and stores them in a hash map with their values. Then before returning the expression, it runs through its components recursively and replaces any known variables with their constant values.

Thanks :metal: 